### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ app.use('/graphql', graphqlExpress((request) => {
   return {
     formatResponse: (response) => {
       if (request.query.deduplicate && response.data && !response.data.__schema) {
-        return deflate(response.data);
+        return deflate(response);
       }
 
       return response;


### PR DESCRIPTION
Fixed code example under "Best practices" "Server-side".

Returning only the deflated `response.data` is incorrect.
Another example returns the deflated `response`, which works in my project.