### PR TITLE
Fix bad Apollo Server "fix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,13 @@ class DeduplicateResponseExtension extends GraphQLExtension {
     const { context, graphqlResponse } = o
     // Ensures `?deduplicate=1` is used in the request
     if (context.req.query.deduplicate && graphqlResponse.data && !graphqlResponse.data.__schema) {
-      const newResponse = deflate(graphqlResponse)
+      const data = deflate(graphqlResponse.data)
       return {
         ...o,
-        graphqlResponse: newResponse,
+        graphqlResponse: {
+          ...graphqlResponse,
+          data,
+        },
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,5 @@
     "test": "NODE_ENV=test nyc --reporter=text ava --verbose --serial"
   },
   "version": "1.0.0",
-  "dependencies": {
-    "is-plain-object": "^3.0.0"
-  }
+  "dependencies": {}
 }

--- a/src/deflate.js
+++ b/src/deflate.js
@@ -1,7 +1,5 @@
 // @flow
 
-import isPlainObject from 'is-plain-object';
-
 // eslint-disable-next-line complexity
 const deflate = (node: Object, index: Object, path: $ReadOnlyArray<string>) => {
   if (node && node.id && node.__typename) {
@@ -24,10 +22,6 @@ const deflate = (node: Object, index: Object, path: $ReadOnlyArray<string>) => {
 
       index[route][node.__typename][node.id] = true;
     }
-  }
-
-  if (!isPlainObject(node)) {
-    return node;
   }
 
   const fieldNames = Object.keys(node);

--- a/test/deflate.js
+++ b/test/deflate.js
@@ -177,18 +177,3 @@ test('does not deconstruct an array of string', (t) => {
     }
   });
 });
-
-// https://github.com/gajus/graphql-deduplicator/issues/13
-test('regression: does not change object types', (t) => {
-  const http = {
-    headers: new Map([['foo', 'bar']])
-  };
-  const response = {
-    http
-  };
-
-  const deflatedResponse: any = deflate(response);
-
-  t.true(deflatedResponse.http.headers instanceof Map);
-  t.deepEqual(deflatedResponse.http.headers.get('foo'), 'bar');
-});


### PR DESCRIPTION
Sorry for the back-and-forth of this. I'm rolling back my fix here as it also rendered `inflate()` useless since my underlying objects weren't plain objects 😳

- When using Apollo, using `.data`  rather than full object
- Underlying objects are likely to not being plain objects