### PR TITLE
Update CI node version and fix Flow warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 9
+  - v10.16.0
 before_install:
   - npm config set depth 0
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - v10.16.0
+  - v10.18.0
 before_install:
   - npm config set depth 0
 cache:

--- a/src/deflate.js
+++ b/src/deflate.js
@@ -1,55 +1,53 @@
 // @flow
 
+type NodeType = Object | $ReadOnlyArray<NodeType>;
+
 // eslint-disable-next-line complexity
-const deflate = (node: Object, index: Object, path: $ReadOnlyArray<string>) => {
-  if (node && node.id && node.__typename) {
-    const route = path.join(',');
-
-    if (index[route] && index[route][node.__typename] && index[route][node.__typename][node.id]) {
-      return {
-        // eslint-disable-next-line id-match
-        __typename: node.__typename,
-        id: node.id,
-      };
-    } else {
-      if (!index[route]) {
-        index[route] = {};
+const deflate = (node: NodeType, index: Object, path: $ReadOnlyArray<string>): NodeType => {
+  if (Array.isArray(node)) {
+    return node.map((childNode) => {
+      if (typeof childNode === 'string' || typeof childNode === 'number' || typeof childNode === 'boolean') {
+        return childNode;
+      } else {
+        return deflate(childNode, index, path);
       }
+    });
+  } else {
+    if (node && node.id && node.__typename) {
+      const route = path.join(',');
 
-      if (!index[route][node.__typename]) {
-        index[route][node.__typename] = {};
-      }
-
-      index[route][node.__typename][node.id] = true;
-    }
-  }
-
-  const fieldNames = Object.keys(node);
-
-  const result = Array.isArray(node) ? [] : {};
-
-  for (const fieldName of fieldNames) {
-    const value = node[fieldName];
-
-    if (Array.isArray(value)) {
-      // $FlowFixMe
-      result[fieldName] = value.map((childNode) => {
-        if (typeof childNode === 'string' || typeof childNode === 'number' || typeof childNode === 'boolean') {
-          return childNode;
+      if (index[route] && index[route][node.__typename] && index[route][node.__typename][node.id]) {
+        return {
+          // eslint-disable-next-line id-match
+          __typename: node.__typename,
+          id: node.id,
+        };
+      } else {
+        if (!index[route]) {
+          index[route] = {};
         }
 
-        return deflate(childNode, index, path.concat([fieldName]));
-      });
-    } else if (typeof value === 'object' && value !== null) {
-      // $FlowFixMe
-      result[fieldName] = deflate(value, index, path.concat([fieldName]));
-    } else {
-      // $FlowFixMe
-      result[fieldName] = value;
-    }
-  }
+        if (!index[route][node.__typename]) {
+          index[route][node.__typename] = {};
+        }
 
-  return result;
+        index[route][node.__typename][node.id] = true;
+      }
+    }
+    const fieldNames = Object.keys(node);
+    const result = {};
+    for (const fieldName of fieldNames) {
+      const value = node[fieldName];
+
+      if (Array.isArray(value) || typeof value === 'object' && value !== null) {
+        result[fieldName] = deflate(value, index, path.concat([fieldName]));
+      } else {
+        result[fieldName] = value;
+      }
+    }
+
+    return result;
+  }
 };
 
 export default (response: Object) => {

--- a/src/inflate.js
+++ b/src/inflate.js
@@ -1,51 +1,49 @@
 // @flow
 
+type NodeType = Object | $ReadOnlyArray<NodeType>;
+
 // eslint-disable-next-line complexity
-const inflate = (node: Object, index: Object, path: $ReadOnlyArray<string>) => {
-  if (node && node.id && node.__typename) {
-    const route = path.join(',');
+const inflate = (node: NodeType, index: Object, path: $ReadOnlyArray<string>): NodeType => {
+  if (Array.isArray(node)) {
+    return node.map((childNode) => {
+      if (typeof childNode === 'string' || typeof childNode === 'number' || typeof childNode === 'boolean') {
+        return childNode;
+      } else {
+        return inflate(childNode, index, path);
+      }
+    });
+  } else {
+    if (node && node.id && node.__typename) {
+      const route = path.join(',');
 
-    if (index[route] && index[route][node.__typename] && index[route][node.__typename][node.id]) {
-      return index[route][node.__typename][node.id];
+      if (index[route] && index[route][node.__typename] && index[route][node.__typename][node.id]) {
+        return index[route][node.__typename][node.id];
+      }
+
+      if (!index[route]) {
+        index[route] = {};
+      }
+
+      if (!index[route][node.__typename]) {
+        index[route][node.__typename] = {};
+      }
+
+      index[route][node.__typename][node.id] = node;
+    }
+    const fieldNames = Object.keys(node);
+    const result = {};
+    for (const fieldName of fieldNames) {
+      const value = node[fieldName];
+
+      if (Array.isArray(value) || typeof value === 'object' && value !== null) {
+        result[fieldName] = inflate(value, index, path.concat([fieldName]));
+      } else {
+        result[fieldName] = value;
+      }
     }
 
-    if (!index[route]) {
-      index[route] = {};
-    }
-
-    if (!index[route][node.__typename]) {
-      index[route][node.__typename] = {};
-    }
-
-    index[route][node.__typename][node.id] = node;
+    return result;
   }
-
-  const fieldNames = Object.keys(node);
-
-  const result = Array.isArray(node) ? [] : {};
-
-  for (const fieldName of fieldNames) {
-    const value = node[fieldName];
-
-    if (Array.isArray(value)) {
-      // $FlowFixMe
-      result[fieldName] = value.map((childNode) => {
-        if (typeof childNode === 'string' || typeof childNode === 'number' || typeof childNode === 'boolean') {
-          return childNode;
-        }
-
-        return inflate(childNode, index, path.concat([fieldName]));
-      });
-    } else if (typeof value === 'object' && value !== null) {
-      // $FlowFixMe
-      result[fieldName] = inflate(value, index, path.concat([fieldName]));
-    } else {
-      // $FlowFixMe
-      result[fieldName] = value;
-    }
-  }
-
-  return result;
 };
 
 export default (response: Object) => {


### PR DESCRIPTION
I saw that the CI was failing after my last PR was merged, so I've tried to fix it here. This fixes two issues:

1. Update Node in CI to version 10.16.0, as it appears to be required for the updated versions of 'eslint' and 'ava'.
1. Update Flow types for inflate/deflate and move handling of arrays to the top of the function, to avoid Flow warnings.

