### PR TITLE
Fixes a case in which inner objects are not inflated.

### DIFF
--- a/src/inflate.js
+++ b/src/inflate.js
@@ -13,22 +13,11 @@ const inflate = (node: NodeType, index: Object, path: $ReadOnlyArray<string>): N
       }
     });
   } else {
+    const route = path.join(',');
     if (node && node.id && node.__typename) {
-      const route = path.join(',');
-
       if (index[route] && index[route][node.__typename] && index[route][node.__typename][node.id]) {
         return index[route][node.__typename][node.id];
       }
-
-      if (!index[route]) {
-        index[route] = {};
-      }
-
-      if (!index[route][node.__typename]) {
-        index[route][node.__typename] = {};
-      }
-
-      index[route][node.__typename][node.id] = node;
     }
     const fieldNames = Object.keys(node);
     const result = {};
@@ -40,6 +29,18 @@ const inflate = (node: NodeType, index: Object, path: $ReadOnlyArray<string>): N
       } else {
         result[fieldName] = value;
       }
+    }
+
+    if (node && node.id && node.__typename) {
+      if (!index[route]) {
+        index[route] = {};
+      }
+
+      if (!index[route][node.__typename]) {
+        index[route][node.__typename] = {};
+      }
+
+      index[route][node.__typename][node.id] = result;
     }
 
     return result;

--- a/test/inflate.js
+++ b/test/inflate.js
@@ -108,7 +108,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
   const deflatedResponse = {
     data: [
       {
-        __typename: 'foo1',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,
@@ -117,7 +117,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
         id: 1,
       },
       {
-        __typename: 'foo2',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,
@@ -125,7 +125,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
         id: 2,
       },
       {
-        __typename: 'foo2',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,
@@ -140,7 +140,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
   t.deepEqual(inflatedResponse, {
     data: [
       {
-        __typename: 'foo1',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,
@@ -149,7 +149,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
         id: 1,
       },
       {
-        __typename: 'foo2',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,
@@ -158,7 +158,7 @@ test('inflates a deflated object (with deflated nested object)', (t) => {
         id: 2,
       },
       {
-        __typename: 'foo2',
+        __typename: 'foo',
         bar: {
           __typename: 'bar',
           id: 1,

--- a/test/inflate.js
+++ b/test/inflate.js
@@ -104,6 +104,72 @@ test('inflates a deflated object (nested; different path)', (t) => {
   });
 });
 
+test('inflates a deflated object (with deflated nested object)', (t) => {
+  const deflatedResponse = {
+    data: [
+      {
+        __typename: 'foo1',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+          name: 'bar',
+        },
+        id: 1,
+      },
+      {
+        __typename: 'foo2',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+        },
+        id: 2,
+      },
+      {
+        __typename: 'foo2',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+        },
+        id: 2,
+      },
+    ],
+  };
+
+  const inflatedResponse = inflate(deflatedResponse);
+
+  t.deepEqual(inflatedResponse, {
+    data: [
+      {
+        __typename: 'foo1',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+          name: 'bar',
+        },
+        id: 1,
+      },
+      {
+        __typename: 'foo2',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+          name: 'bar',
+        },
+        id: 2,
+      },
+      {
+        __typename: 'foo2',
+        bar: {
+          __typename: 'bar',
+          id: 1,
+          name: 'bar',
+        },
+        id: 2,
+      },
+    ],
+  });
+});
+
 test('does not deconstruct an array of string', (t) => {
   const deflatedResponse = {
     data: {


### PR DESCRIPTION
The use case is as Follows:
An array of:
1. Object A with nested object N
2. Object B with nested object N
3. Object B with nested object N (duplicated)

While iterating over A an inflated N is added to the index.
When reaching the first B object it is added to the index, but it is added before inflating its inner properties. So A is in the index with a deflated N.
When reaching the duplicated B object it is fetched from the index and has a deflated N.

I added a test that reproduce the issue.

Notice that when testing with Apollo-client it will reproduce only when fetch policy has cache. 

The fix is to add objects to the index only after inflating their properties.