### PR TITLE
Fix: handle null values in arrays

### DIFF
--- a/src/deflate.js
+++ b/src/deflate.js
@@ -13,6 +13,11 @@ const deflate = (node: NodeType, index: Object, path: $ReadOnlyArray<string>): N
       }
     });
   } else {
+    // Handle null and undefined by preserving them
+    if (node === null || node === undefined) {
+      return node;
+    }
+
     if (node && node.id && node.__typename) {
       const route = path.join(',');
 

--- a/test/deflate.js
+++ b/test/deflate.js
@@ -263,3 +263,65 @@ test('does not deconstruct a nested array', (t) => {
     },
   });
 });
+
+test('does not modify null values', (t) => {
+  const response = {
+    data: null,
+  };
+
+  const deflatedResponse = deflate(response);
+
+  t.deepEqual(deflatedResponse, {
+    data: null,
+  });
+});
+
+test('does not modify objects with null fields', (t) => {
+  const response = {
+    bar: null,
+    foo: {
+      __typename: 'foo',
+      id: 1,
+      name: 'bar',
+    },
+  };
+
+  const deflatedResponse = deflate(response);
+
+  t.deepEqual(deflatedResponse, {
+    bar: null,
+    foo: {
+      __typename: 'foo',
+      id: 1,
+      name: 'bar',
+    },
+  });
+});
+
+test('does not deconstruct an array with null elements', (t) => {
+  const response = {
+    data: [
+      {
+        __typename: 'foo',
+        id: 1,
+        items: [
+          null,
+        ],
+      },
+    ],
+  };
+
+  const deflatedResponse = deflate(response);
+
+  t.deepEqual(deflatedResponse, {
+    data: [
+      {
+        __typename: 'foo',
+        id: 1,
+        items: [
+          null,
+        ],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
* Handle null values in arrays by preserving them. Before this `Object.keys(node)` would throw for null nodes.
* Add tests for this case and other null cases